### PR TITLE
Adds grid reliability calculations

### DIFF
--- a/data/reliability_requirements.ipynb
+++ b/data/reliability_requirements.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Reliability Requirements\n",
+    "\n",
+    "Grid operators must plan for resource adequacy. The typical metric for assuring this resource adequacy is the \"planning reserve margin\" (PRM). The North American Electric Reliability Corporation (NERC) [recommends](https://www.nerc.com/pa/RAPA/ra/Reliability%20Assessments%20DL/IVGTF1-2.pdf) around a 15% PRM. \n",
+    "\n",
+    "The planning reserve margin is defined as \n",
+    "\n",
+    "\n",
+    "$$ PRM = \\frac{ C_{\\text{firm}} - D_{\\text{peak}} }{ D_{\\text{peak}} }\\\\\n",
+    "C_{\\text{firm}} = \\text{The firm capacity  [GW]}\\\\\n",
+    "D_{\\text{peak}} = \\text{The peak demand  [GW]}$$\n",
+    "\n",
+    "\n",
+    "Firm capacity is sometimes considered the amount of power guaranteed to be available for the duration of a commitment. We consider firm capacity to be the amount of power that is available \"on-demand.\" Thus, renewable energy sources do not contribute to firm capacity.\n",
+    "Since we insist on carbon free electricity by 2030 in our simulations, the only technologies available to contribute to firm capacity are \n",
+    "1. Nuclear power\n",
+    "2. Battery or other kind of storage\n",
+    "\n",
+    "We can calculate the required battery storage for each year in the simulation with the following method:\n",
+    "1. Conduct Temoa simulation and observe the available capacity for both existing and advanced nuclear technologies.\n",
+    "2. Use the above equation to calculate the required battery storage\n",
+    "\n",
+    "Based on the HOMER simulation, we estimate the peak demand as 54.39 GW. Any year with zero nuclear capacity thus has a battery storage requirement of (to meet the NERC recommendation):\n",
+    "\n",
+    "$$\n",
+    "PRM = \\frac{C_{firm}}{D_{peak}} - 1 = \\frac{C_{battery}+C_{nuclear}}{D_{peak}} - 1\\\\\n",
+    "(PRM+1)\\cdot D_{peak}-C_{nuclear} = C_{battery}\\\\\n",
+    "C_{battery} = (0.15+1)\\cdot 54.39 [GW]\\\\\n",
+    "= 62.56 [GW]\n",
+    "$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Approximately 62.5485 GW of battery capacity is required to meet NERC reliability recommendations.\n"
+     ]
+    }
+   ],
+   "source": [
+    "PRM = 0.15\n",
+    "nuclear_cap = 0.0  # GW\n",
+    "demand_peak = 54.39  # GW\n",
+    "battery_cap = (PRM+1)*demand_peak - nuclear_cap\n",
+    "\n",
+    "print(f'Approximately {battery_cap} GW of battery capacity is required to meet NERC reliability recommendations.')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This PR adds ``reliability_requirements.ipynb`` which calculates the required battery capacity to meet the recommended NERC planning reserve margin. 

Importantly, this is likely an _underestimate_ because:
1. NERC states that a grids with identical reserve margins may have different actual reliabilities
2. All available literature on setting a planning reserve margin only use a renewable energy penetration of 35%. 